### PR TITLE
Not needed anymore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,3 @@ MIT
 
 * for PXT/microbit
 (The metadata above is needed for package search.)
-
-
-```package
-pxt-kitronik-accessbit=github:KitronikLtd/pxt-kitronik-accessbit
-```


### PR DESCRIPTION
The cloud automatically adds a reference to the current package.