### PR TITLE
Correct badly rendered link and blocks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,21 @@
 
 # Kitronik blocks for micro:bit
 
-Blocks that support [Kitronik kits and shields for the micro:bit](https://www.kitronik.co.uk/microbit.html)
-This package is for the [Kitronik ACCESS:bit] (http://www.kitronik.co.uk/5646)
+Blocks that support [Kitronik kits and shields for the micro:bit](https://www.kitronik.co.uk/microbit.html).  
+This package is for the [Kitronik ACCESS:bit](http://www.kitronik.co.uk/5646).
 
 ## ACCESS:bit
 
 * Move a selected barrier
 
 ```blocks
-	Kitronik_ACCESSbit.barrierControl(Up)
+    Kitronik_ACCESSbit.barrierControl(Kitronik_ACCESSbit.BarrierPosition.Up)
 ```
 
 * Sound the buzzer
 
 ```blocks
-    Kitronik_ACCESSbit.buzzerControl(Short, 2)
+    Kitronik_ACCESSbit.buzzerControl(Kitronik_ACCESSbit.BuzzerLength.Short, 2)
 ```
 ## License
 
@@ -25,4 +25,3 @@ MIT
 ## Supported targets
 
 * for PXT/microbit
-(The metadata above is needed for package search.)


### PR DESCRIPTION
See https://makecode.microbit.org/pkg/KitronikLtd/pxt-kitronik-accessbit#access-bit for unrendered blocks